### PR TITLE
fixed typo in Python 2.7 Notice Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Use *Tiled* map editor: http://www.mapeditor.org/
 Python 2.7 Notice
 -----------------
 
-We will be supporing bugfixes and features for python 2.7+ after it
+We will be supporting bugfixes and features for python 2.7+ after it
 is EOL starting in 2020.  We do plan on removing support for it
 sometime in the future, but there is currently no roadmap to actively
 stop supporting it at this time.


### PR DESCRIPTION
"supporing" -> "supporting"